### PR TITLE
Replace obsolete project (Notes) with ScripSheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ If you are the maintainer of a project, you can add our badge by copying the cod
 - **[NestJs MongoDB Base Crud API](https://github.com/babacarbasse/nestjs-mongo-crud-base)** - A NestJS package that allow you setup quickly CRUD entities in your NestJS Mongo Application. - **[@babacarbasse](https://github.com/babacarbasse)**
 - **[Netflix Collection](https://github.com/mouhamedhanne/Netflix_collection)** - Your perfect companion for easy management of your favorite movies and TV shows. - **[@mouhamedhanne](https://github.com/mouhamedhanne)**
 - **[NextJs 14 Shadcn/ui Boilerplate](https://github.com/lucien-loua/nextjs14-shadcnui-boilerplate)** - A NextJs 14 Boilerplate with Shadcn/ui, Next Themes, TypeScript, ESLint. - **[@lucien-loua](https://github.com/lucien-loua)**
-- **[Notes](https://github.com/EIC95/Notes)** - Notes on programming languages offering an overview of basic concepts and essential features. - **[@EIC95](https://github.com/EIC95)**
 - **[NumMenu Bot](https://github.com/DerXter/NumMenu-Bot)** - A chatbot example with a number-based menu, ideal as a project starter. - **[@DerXter](https://github.com/DerXter)**
 
 ## O
@@ -204,6 +203,7 @@ If you are the maintainer of a project, you can add our badge by copying the cod
 - **[Samane](https://github.com/ngorseckframework/samanemvc)** - PHP Framework using MVC model developed by Ngor SECK. - **[@ngorseckframework](https://github.com/ngorseckframework)**
 - **[Sard Form](https://github.com/mouhamed1296/sard-form)** - A React Component Library for building and maintaining Form easily. - **[@mouhamed1296](https://github.com/mouhamed1296)**
 - **[Senegal Phone Validator](https://github.com/okemamy/senegal-phone-validator)** - A minimal module to validate Senegal phone numbers using Regular Expressions. - **[@okemamy](https://github.com/okemamy)**
+- **[ScriptSheets](https://github.com/EIC95/ScriptSheets)** - An open-source project that provides a collection of cheat sheets for various programming languages and technologies. - **[@EIC95](https://github.com/EIC95)**
 - **[SGML Parser & Converter](https://github.com/TiDev00/Sgml_Parser)** - A Python tool to parse SGML files from WMT and convert them into TXT files. - **[@TiDev00](https://github.com/TiDev00)**
 - **[Spicy Object](https://github.com/mouhamed1296/spicy-object)** - A Js/Ts Library that allows developers to easily manipulate JavaScript objects. - **[@mouhamed1296](https://github.com/mouhamed1296)**
 - **[Sprint](https://github.com/zlorgoncho1/sprint)** - A lightweight, high-performance Go web framework with built-in JSON and HTML response support. - **[@zlorgoncho1](https://github.com/zlorgoncho1)**


### PR DESCRIPTION
Hi 👋,

This PR replaces an obsolete project with ScripSheets, an open-source platform providing structured notes and cheat sheets for various programming languages and technologies. ScripSheets offers a more relevant and updated resource for developers, ensuring quick access to essential references.

Changes made:
- Removed the outdated project
- Added ScripSheets as the replacement

Let me know if any modifications are needed. Thanks! 